### PR TITLE
Balance the LINUX category

### DIFF
--- a/bot/src/com/github/corruptedinc/corruptedmainframe/commands/fights/Attack.kt
+++ b/bot/src/com/github/corruptedinc/corruptedmainframe/commands/fights/Attack.kt
@@ -6,7 +6,7 @@ import kotlin.random.Random.Default.nextInt
 
 interface Attack {
     enum class Category(val bitmask: ULong, val pickable: Boolean = true) {
-        GENERAL(0b1U), FRC(0b10U), TECHNICAL(0b100U), BOT(0b1UL shl 63, false)
+        GENERAL(0b1U), FRC(0b10U), TECHNICAL(0b100U), LINUX(0b1000U), BOT(0b1UL shl 63, false)
     }
 
     companion object {
@@ -66,6 +66,27 @@ interface Attack {
             InstakillAttack(Category.BOT, 0.1, "%a compressed some lithium-6 deuteride!", 0),
             InstakillAttack(Category.BOT, 0.1, "%a is become death, destroyer of worlds!", 0),
             InstakillAttack(Category.BOT, 0.25, "%a violated the geneva conventions!", 0),
+            
+            // LINUX
+            // REGULAR ATTACKS
+            SimpleAttack(Category.LINUX, 1.0, "%a unleashed the penguins!", 0, 10.0, 1.0, 0.35),
+            SimpleAttack(Category.LINUX, 0.5, "%a installed TempleOS on %v's computer!", 2, 15.0, 1.0, 0.3),
+            SimpleAttack(Category.LINUX, 0.5, "%a ranted for 3 hours about systemd!", 5, 30.0, 1.0, 0.75),
+            SimpleAttack(Category.LINUX, 0.5, "%a told %v their rice sucks!", 8, 20.0, 1.0, 0.5),
+            SimpleAttack(Category.LINUX, 0.25, "%a ran rm -rf /home/%v", 15, 60.0, 2.0, 0.85),
+            SimpleAttack(Category.LINUX, 0.5, "%a installed a virus on %v's computer", 0, 15.0, 1.0, 0.5),
+            SimpleAttack(Category.LINUX, 0.5, "%a messed with %v's grub config!", 6, 45.0, 1.0, 0.5),
+            SimpleAttack(Category.LINUX, 0.5, "%a exploited dirtycow!", 20, 75.0, 2.0, 0.5),
+            // CRITICAL MISSES LINUX
+            SimpleAttack(Category.LINUX, 0.2, "%v attempted to delete a virus but ran rm -rf on root!", 0, 15.0, 1.0, 0.5),
+            SimpleAttack(Category.LINUX, 0.15, "%v failed their Gentoo install 7 days in!", 8, 45.0, 2.0, 0.5),
+            SimpleAttack(Category.LINUX, 0.2, "%v couldn't run their game with proton and cried!", 0, 10.0, 1.0, 0.5),
+            SimpleAttack(Category.LINUX, 0.15, "%v accidentally deleted /bin/!", 0, 20.0, 1.0, 0.5),
+            // INSTANT LINUX
+            InstakillAttack(Category.LINUX, 0.0125, "%a zeroed %v's hard-drive!", 15),
+            InstakillAttack(Category.LINUX, 0.0100, "sudo rm -rf /*", 10),
+            InstakillAttack(Category.LINUX, 0.0025, "I'd just like to interject for a moment...", 5),
+            // TODO: Balance damage and scaling (Probably won't happen, but this way I feel better about myself)
         )
 
         fun pickAttack(level: Int, categories: List<Category> = listOf(Category.GENERAL)): Attack {


### PR DESCRIPTION
It happened! I actually followed up with previous work!
These are fairly small changes making instant kills more likely, but in turn reduces the power of most of the simple attacks.
Battles should go on longer with more chances for lower level users to beat higher level users...
Also the instant is more likely to give a little more variation. I've reduced the chance of most `rm -rf` related attacks in further effort to increase variation.
You'll notice a PR in my commit log. This was so I could easily compare changes to the current branch I had and ensure all code was preserved.